### PR TITLE
Add ndg.httpsclient recipe

### DIFF
--- a/pythonforandroid/recipes/ndghttpsclient
+++ b/pythonforandroid/recipes/ndghttpsclient
@@ -1,0 +1,9 @@
+from pythonforandroid.toolchain import PythonRecipe
+
+class NdgHttpsClientRecipe(PythonRecipe):
+    version = '0.4.0'
+    url = 'https://pypi.python.org/packages/source/n/ndg-httpsclient/ndg_httpsclient-{version}.tar.gz'
+    depends = ['python2', 'pyopenssl', 'cryptography']
+    call_hostpython_via_targetpython = False
+
+recipe = NdgHttpsClientRecipe()


### PR DESCRIPTION
requests with ssl needs ngd.httpsclient. Unfortunately it when it is installed in the build environment with pip it grabs it's dependencies from pip which messes up the resulting APK. Thus this recipe is needed.
